### PR TITLE
Add the new 'smart' implementation of Composer's class loader

### DIFF
--- a/src/Seld/AutoloadBench/Builder/ComposerSmart.php
+++ b/src/Seld/AutoloadBench/Builder/ComposerSmart.php
@@ -6,7 +6,7 @@ use Seld\AutoloadBench\Builder;
 
 class ComposerSmart extends Builder
 {
-    public function build($classes, $path)
+    public function build($classes, $path, $prefixMapLevel = 1)
     {
         $code = <<<'EOF'
 <?php
@@ -24,7 +24,7 @@ EOF
 
         $prefixes = array();
         foreach ($classes as $class) {
-            $prefix = substr($class, 0, strpos($class, '\\'));
+            $prefix = implode('\\', array_slice(explode('\\', $class), 0, $prefixMapLevel));
             $prefixes[$prefix] = $path;
         }
 

--- a/src/Seld/AutoloadBench/Builder/ComposerSmart.php
+++ b/src/Seld/AutoloadBench/Builder/ComposerSmart.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Seld\AutoloadBench\Builder;
+
+use Seld\AutoloadBench\Builder;
+
+class ComposerSmart extends Builder
+{
+    public function build($classes, $path)
+    {
+        $code = <<<'EOF'
+<?php
+
+$loader = new \Seld\AutoloadBench\Loader\ComposerSmart();
+$map = %s;
+
+foreach ($map as $prefix => $path) {
+    $loader->add($prefix, $path);
+}
+
+return $loader;
+EOF
+;
+
+        $prefixes = array();
+        foreach ($classes as $class) {
+            $prefix = substr($class, 0, strpos($class, '\\'));
+            $prefixes[$prefix] = $path;
+        }
+
+        file_put_contents($this->path.'/loader.php', sprintf($code, var_export($prefixes, true)));
+    }
+}

--- a/src/Seld/AutoloadBench/Loader/ComposerSmart.php
+++ b/src/Seld/AutoloadBench/Loader/ComposerSmart.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Seld\AutoloadBench\Loader;
+
+/*
+ * Copied from Composer sources (MIT licensed)
+ *
+ * (c) Nils Adermann <naderman@naderman.de>
+ *     Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * This class is loosely based on the Symfony UniversalClassLoader.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class ComposerSmart
+{
+    private $prefixes = array();
+    private $fallbackDirs = array();
+    private $useIncludePath = false;
+    private $classMap = array();
+
+    /**
+     * @param array $classMap Class to filename map
+     */
+    public function addClassMap(array $classMap)
+    {
+        if ($this->classMap) {
+            $this->classMap = array_merge($this->classMap, $classMap);
+        } else {
+            $this->classMap = $classMap;
+        }
+    }
+
+    /**
+     * Registers a set of classes, merging with any others previously set.
+     *
+     * @param string       $prefix  The classes prefix
+     * @param array|string $paths   The location(s) of the classes
+     * @param bool         $prepend Prepend the location(s)
+     */
+    public function add($prefix, $paths, $prepend = false)
+    {
+        if (!$prefix) {
+            if ($prepend) {
+                $this->fallbackDirs = array_merge(
+                    (array) $paths,
+                    $this->fallbackDirs
+                );
+            } else {
+                $this->fallbackDirs = array_merge(
+                    $this->fallbackDirs,
+                    (array) $paths
+                );
+            }
+
+            return;
+        }
+
+        $first = $prefix[0];
+        if (!isset($this->prefixes[$first][$prefix])) {
+            $this->prefixes[$first][$prefix] = (array) $paths;
+
+            return;
+        }
+        if ($prepend) {
+            $this->prefixes[$first][$prefix] = array_merge(
+                (array) $paths,
+                $this->prefixes[$first][$prefix]
+            );
+        } else {
+            $this->prefixes[$first][$prefix] = array_merge(
+                $this->prefixes[$first][$prefix],
+                (array) $paths
+            );
+        }
+    }
+
+    /**
+     * Loads the given class or interface.
+     *
+     * @param  string       $class The name of the class
+     * @return Boolean|null True, if loaded
+     */
+    public function loadClass($class)
+    {
+        if ($file = $this->findFile($class)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Finds the path to the file where the class is defined.
+     *
+     * @param string $class The name of the class
+     *
+     * @return string|false The path if found, false otherwise
+     */
+    public function findFile($class)
+    {
+        // work around for PHP 5.3.0 - 5.3.2 https://bugs.php.net/50731
+        if ('\\' == $class[0]) {
+            $class = substr($class, 1);
+        }
+
+        if (isset($this->classMap[$class])) {
+            return $this->classMap[$class];
+        }
+
+        if (false !== $pos = strrpos($class, '\\')) {
+            // namespaced class name
+            $classPath = strtr(substr($class, 0, $pos), '\\', DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+            $className = substr($class, $pos + 1);
+        } else {
+            // PEAR-like class name
+            $classPath = null;
+            $className = $class;
+        }
+
+        $classPath .= strtr($className, '_', DIRECTORY_SEPARATOR) . '.php';
+
+        $first = $class[0];
+        if (isset($this->prefixes[$first])) {
+            foreach ($this->prefixes[$first] as $prefix => $dirs) {
+                if (0 === strpos($class, $prefix)) {
+                    foreach ($dirs as $dir) {
+                        if (file_exists($dir . DIRECTORY_SEPARATOR . $classPath)) {
+                            return $dir . DIRECTORY_SEPARATOR . $classPath;
+                        }
+                    }
+                }
+            }
+        }
+
+        foreach ($this->fallbackDirs as $dir) {
+            if (file_exists($dir . DIRECTORY_SEPARATOR . $classPath)) {
+                return $dir . DIRECTORY_SEPARATOR . $classPath;
+            }
+        }
+
+        if ($this->useIncludePath && $file = stream_resolve_include_path($classPath)) {
+            return $file;
+        }
+
+        return $this->classMap[$class] = false;
+    }
+}


### PR DESCRIPTION
Composer class loader has changed.
https://github.com/composer/composer/commit/94175ce432e30712fa46ceff1fdee49727542263
It checks the first character of a class, to pre-select prefixes. This is cool!

Adding a "ComposerSmart" class to reflect the changes, and to allow comparison with the old version.
