### PR TITLE
Variations of how prefixes are registered.

### DIFF
--- a/bin/bench
+++ b/bin/bench
@@ -4,5 +4,12 @@
 require __DIR__.'/../vendor/autoload.php';
 
 (new Seld\AutoloadBench\Runner(dirname(__DIR__).'/build'))
-    ->prepare(3000)
-    ->run([200, 500, -500], 100);
+    ->prepare(2000)
+    ->run([200, 500, -500], 100)
+    ->prepare(1000, 'SharedVendor\\')
+    ->run([300], 100)
+    ->prepare(1000, 'SharedVendor\\', 2)
+    ->run([300], 100)
+    ->prepare(1000, '', 2)
+    ->run([300], 40)
+;

--- a/src/Seld/AutoloadBench/Builder.php
+++ b/src/Seld/AutoloadBench/Builder.php
@@ -12,7 +12,12 @@ abstract class Builder
         $this->path = $path;
     }
 
-    abstract public function build($classes, $path);
+    public function prepare($classes, $path, $prefixMapLevel = 1) {
+        $this->build($classes, $path, $prefixMapLevel);
+        $this->instance = NULL;
+    }
+
+    abstract protected function build($classes, $path);
 
     public function enabled()
     {

--- a/src/Seld/AutoloadBench/Builder/APC.php
+++ b/src/Seld/AutoloadBench/Builder/APC.php
@@ -6,8 +6,11 @@ use Seld\AutoloadBench\Builder;
 
 class APC extends Builder
 {
-    public function build($classes, $path)
+    protected function build($classes, $path)
     {
+        if (function_exists('apc_clear_cache')) {
+            apc_clear_cache('user');
+        }
         $code = '<?php return new \Seld\AutoloadBench\Loader\APC(%s);';
 
         foreach ($classes as $class) {

--- a/src/Seld/AutoloadBench/Builder/ClassMap.php
+++ b/src/Seld/AutoloadBench/Builder/ClassMap.php
@@ -6,7 +6,7 @@ use Seld\AutoloadBench\Builder;
 
 class ClassMap extends Builder
 {
-    public function build($classes, $path)
+    protected function build($classes, $path)
     {
         $code = '<?php return new \Seld\AutoloadBench\Loader\ClassMap(%s);';
 

--- a/src/Seld/AutoloadBench/Builder/Composer.php
+++ b/src/Seld/AutoloadBench/Builder/Composer.php
@@ -6,7 +6,7 @@ use Seld\AutoloadBench\Builder;
 
 class Composer extends Builder
 {
-    public function build($classes, $path)
+    protected function build($classes, $path, $prefixMapLevel = 1)
     {
         $code = <<<'EOF'
 <?php
@@ -24,7 +24,7 @@ EOF
 
         $prefixes = array();
         foreach ($classes as $class) {
-            $prefix = substr($class, 0, strpos($class, '\\'));
+            $prefix = implode('\\', array_slice(explode('\\', $class), 0, $prefixMapLevel));
             $prefixes[$prefix] = $path;
         }
 

--- a/src/Seld/AutoloadBench/Builder/PSR0.php
+++ b/src/Seld/AutoloadBench/Builder/PSR0.php
@@ -6,7 +6,7 @@ use Seld\AutoloadBench\Builder;
 
 class PSR0 extends Builder
 {
-    public function build($classes, $path)
+    protected function build($classes, $path, $prefixMapLevel = 1)
     {
         $code = <<<'EOF'
 <?php
@@ -24,7 +24,7 @@ EOF
 
         $prefixes = array();
         foreach ($classes as $class) {
-            $prefix = substr($class, 0, strpos($class, '\\'));
+            $prefix = implode('\\', array_slice(explode('\\', $class), 0, $prefixMapLevel));
             $prefixes[$prefix] = $path;
         }
 

--- a/src/Seld/AutoloadBench/Generator.php
+++ b/src/Seld/AutoloadBench/Generator.php
@@ -55,11 +55,11 @@ class Generator
         'Config', 'Bridge', 'Logout', 'DateFormat', 'Core',
     ];
 
-    public function generate($amount, $path)
+    public function generate($amount, $path, $sharedPrefix = '')
     {
         $classes = [];
         while ($amount--) {
-            $class = $this->generateName();
+            $class = $sharedPrefix . $this->generateName();
             $file = $path.'/'.strtr($class, '\\', '/').'.php';
             if (!is_dir(dirname($file))) {
                 mkdir(dirname($file), 0777, true);

--- a/src/Seld/AutoloadBench/Runner.php
+++ b/src/Seld/AutoloadBench/Runner.php
@@ -34,17 +34,24 @@ class Runner
         }
     }
 
-    public function prepare($numClasses)
+    public function prepare($numClasses, $sharedPrefix = '', $prefixMapLevel = 1)
     {
         $gen = new Generator;
         if (!is_dir($this->path.'/classes')) {
             mkdir($this->path.'/classes', 0777, true);
         }
 
+        echo PHP_EOL;
         echo 'Generating '.$numClasses.' classes'.PHP_EOL;
-        $this->classes = $gen->generate($numClasses, $this->path.'/classes');
+        if (!empty($sharedPrefix)) {
+            echo 'Shared prefix: ' . $sharedPrefix . PHP_EOL;
+        }
+        if (1 !== $prefixMapLevel) {
+            echo 'Prefix level for PSR-0: ' . $prefixMapLevel . PHP_EOL;
+        }
+        $this->classes = $gen->generate($numClasses, $this->path.'/classes', $sharedPrefix);
         foreach ($this->builders as $name => $builder) {
-            $builder->build($this->classes, $this->path.'/classes');
+            $builder->prepare($this->classes, $this->path.'/classes', $prefixMapLevel);
         }
 
         return $this;
@@ -101,8 +108,16 @@ class Runner
                     $start = microtime(true);
                     $loader = $builder->getLoader();
                     foreach ($toLoad as $class) {
-                        if ($expected !== $loader->loadClass($class)) {
-                            throw new \RuntimeException($name.' failed to process '.$class);
+                        if ($expected !== $loaderResult = $loader->loadClass($class)) {
+                            if (FALSE === $loaderResult) {
+                                throw new \RuntimeException($name.' failed to load '.$class);
+                            }
+                            elseif (TRUE === $loaderResult) {
+                                throw new \RuntimeException($name.' must not load '.$class);
+                            }
+                            else {
+                                throw new \RuntimeException($name.' must return TRUE or FALSE.');
+                            }
                         }
                     }
                     $results[$name]['runs'][$run] = microtime(true) - $start;
@@ -138,5 +153,7 @@ class Runner
 
             echo PHP_EOL;
         }
+
+        return $this;
     }
 }


### PR DESCRIPTION
The following changes:
- multiple prepare() with different variations of classes and namespaces.
- parameter $sharedPrefix allows to let all classes live in the same top-level namespace.
- parameter $prefixMapLevel allows to register second-level namespaces in PSR-0, thus horribly exploding the map of registered namespaces.

Why?

Composer class loader has a new "smart" implementation.
https://github.com/Seldaek/autoload-bench/pull/5
It checks the first character of a class, to pre-select prefixes.

This will be cool if registered namespaces are randomly distributed.
However, it won't help if all registered namespaces begin with the same first character.
E.g. if all registered namespaces are packages of the same framework or CMS, such as

```
Drupal\system -> modules/system/lib
Drupal\node -> modules/node/lib
Drupal\user -> modules/user/lib
...
```

This is a real-world use case..
