### PR TITLE
Add cdb (constant database) loader

### DIFF
--- a/bin/bench
+++ b/bin/bench
@@ -12,4 +12,6 @@ require __DIR__.'/../vendor/autoload.php';
     ->run([300], 100)
     ->prepare(1000, '', 2)
     ->run([300], 40)
+    ->prepare(8000, 'SharedVendor\\')
+    ->run([300], 100)
 ;

--- a/src/Seld/AutoloadBench/Builder/Cdb.php
+++ b/src/Seld/AutoloadBench/Builder/Cdb.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Seld\AutoloadBench\Builder;
+
+use Seld\AutoloadBench\Builder;
+
+class Cdb extends Builder
+{
+    protected function build($classes, $path)
+    {
+        $dbfile = $this->path . '/loader.cdb';
+
+        $cdb = dba_open($dbfile, 'n', 'cdb');
+
+        foreach ($classes as $class) {
+            dba_insert($class, $path.'/'.strtr($class, '\\', '/').'.php', $cdb);
+        }
+
+        dba_close($cdb);
+
+        $code = '<?php return new \Seld\AutoloadBench\Loader\Cdb(\'%s\');';
+
+        file_put_contents($this->path.'/loader.php', sprintf($code, $dbfile));
+    }
+}
+

--- a/src/Seld/AutoloadBench/Builder/Cdb.php
+++ b/src/Seld/AutoloadBench/Builder/Cdb.php
@@ -22,5 +22,10 @@ class Cdb extends Builder
 
         file_put_contents($this->path.'/loader.php', sprintf($code, $dbfile));
     }
+
+    public function enabled()
+    {
+        return extension_loaded('dba') && in_array('cdb', dba_handlers());
+    }
 }
 

--- a/src/Seld/AutoloadBench/Loader/Cdb.php
+++ b/src/Seld/AutoloadBench/Loader/Cdb.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seld\AutoloadBench\Loader;
+
+class Cdb
+{
+    private $cdb;
+
+    public function __construct($dbfile)
+    {
+        $this->cdb = dba_open($dbfile, 'r-', 'cdb');
+    }
+
+    public function loadClass($name)
+    {
+        $file = dba_fetch($name, $this->cdb);
+
+        if ($file !== false) {
+            return true;
+        }
+
+        return false;
+    }
+}
+


### PR DESCRIPTION
From the PHP documentation:

> Cdb is "a fast, reliable, lightweight package for creating and reading constant databases."

I've run into a use case where the classmap autoloader in composer doesn't seem to be the optimal solution. A project at my company with a large number of dependencies (ZF2 _and_ ZF1, lots of proprietary libraries) has a classmap of about 8000 entries. Loading this map takes considerable time and memory. Yet for a typical request only about 300 classes will actually be loaded.

So I gave good old cdb a try. It seems to beat most of the other loaders in this benchmark in many scenarios.

Since I only tested this on a virtual machine (windows host, linux guest, php 5.5), I'm very interested in your feedback.
